### PR TITLE
fix: update getSurveyQuestions return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export class WebropolApiClient {
   }
 
   /** Gets all questions for a survey, returns QuestionId, QuestionText and QuestionOrderNumber. */
-  async getSurveyQuestions(surveyId: string): Promise<IQuestion[]> {
+  async getSurveyQuestions(surveyId: string): Promise<{ Questions: IQuestion[] }> {
     return await this.request('GET', `surveys/${surveyId}/questions`);
   }
 


### PR DESCRIPTION
It seems that at one point the return type of `getSurveyQuestions` has fallen out of date, as currently the response list of `IQuestion`s is wrapped in the following shape: `{ Questions: IQuestion[] }`