### PR TITLE
Feat/survey responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export class WebropolApiClient {
   }
 
   /** Gets all questions for a survey, returns QuestionId, QuestionText and QuestionOrderNumber. */
-  async getSurveyQuestions(surveyId: string): Promise<IQuestion[]> {
+  async getSurveyQuestions(surveyId: string): Promise<{ Questions: IQuestion[] }> {
     return await this.request('GET', `surveys/${surveyId}/questions`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import got, { Headers, Method, OptionsOfJSONResponseBody } from 'got';
-import { IQuestion, ISurvey, ISurveyAnswers, ISurveyQuestionAnswers, IWebropolApiClientOptions, IWebropolApiFilter } from './interfaces';
+import { IQuestion, ISurvey, ISurveyAnswers, ISurveyQuestionAnswers, ISurveyResponse, IWebropolApiClientOptions, IWebropolApiFilter, IWebropolApiRequestOptions } from './interfaces';
 
 export class WebropolApiClient {
   options: IWebropolApiClientOptions;
@@ -102,13 +102,27 @@ export class WebropolApiClient {
     return await this.request('GET', `surveys/${surveyId}/questions`);
   }
 
-  /** Gets all answers for one survey that is specified in the request with the surveyId. Optional filters: StartDate and EndDate. */
+  /**
+   * Gets all answers for one survey that is specified in the request with the surveyId. Optional filters: StartDate and EndDate.
+   * 
+   * This API endpoint will be deprecated, and you should use `getSurveyResponses` instead.
+   * @deprecated
+   */
   async getSurveyAnswers(surveyId: string, filters?: IWebropolApiFilter): Promise<ISurveyAnswers> {
     if (filters) {
       return await this.request('POST', `surveys/${surveyId}/answers`, filters);
     }
 
     return await this.request('GET', `surveys/${surveyId}/answers`);
+  }
+
+  /** Gets all responses for one survey that is specified in the request with the surveyId. Optional filters: StartDate and EndDate. */
+  async getSurveyResponses(surveyId: string, options?: IWebropolApiRequestOptions): Promise<ISurveyResponse> {
+    if (options?.filters) {
+      return await this.request('POST', `surveys/${surveyId}/responses`, options.filters, options.params);
+    }
+
+    return await this.request('GET', `surveys/${surveyId}/responses`, undefined, options?.params);
   }
 
   /** Gets all answers for one question in survey that is specified in the request with the surveyId and questionId. Optional filters: StartDate and EndDate. */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,6 +21,15 @@ export interface IWebropolApiFilter {
   RespondentId?: string;
 }
 
+export interface IWebropolApiParams {
+  paging?: number;
+}
+
+export interface IWebropolApiRequestOptions {
+  filters?: IWebropolApiFilter;
+  params?: IWebropolApiParams;
+}
+
 export interface ISurvey {
   SurveyId: string;
   SurveyTitle: string;
@@ -99,4 +108,60 @@ export interface IRespondentQuestionAnswerAnswer {
   AnswerFile?: string;
 
   [propName: string]: any;
+}
+
+export interface IPaging {
+  ItemsPerPage: number;
+  TotalCount: number;
+  TotalPages: number;
+  CurrentPage: number;
+  IsLastItemFetched: boolean;
+  ItemCount: number;
+}
+
+type QuestionTypeName =
+  | "questionType_openended"
+  | "questionType_textField"
+  | "questionType_NPS"
+  | "questionType_selection"
+  | "questionType_multipleChoice"
+  | "questionType_DropDownList"
+  | "questionType_scaleSelection"
+  | "questionType_scaleMultipleChoice"
+  | "questionType_position"
+  | "questionType_fourfold";
+
+export interface IQuestionAnswer {
+  OptionAnswer: string;
+  QuestionOptionId: string;
+  OptionId?: string;
+  AnswerOptionId: string;
+  AttahedTextFieldValue?: string;
+  RowText?: string;
+  AnswerFile?: string;
+}
+
+export interface IRespondentAnswerNew {
+  Keywords?: string;
+  QuestionId: string;
+  QuestionTitle: string;
+  QuestionTypeId: string;
+  QuestionTypeName: QuestionTypeName;
+  Label?: string;
+  QuestionAnswers: IQuestionAnswer[];
+}
+
+export interface ISurveyAnswer {
+  RespondentId: string;
+  ResponseId: string;
+  RespondentEmail: string;
+  ResponseLanguageId: string;
+  ResponseDate: string;
+  RespondentAnswers: IRespondentAnswerNew[];
+}
+
+export interface ISurveyResponse {
+  SurveyId: string;
+  Paging: IPaging;
+  SurveyAnswers: ISurveyAnswer[];
 }


### PR DESCRIPTION
Adds a new method, `getSurveyResponses`, for the new `surveys/{{surveyId}}/responses` endpoint, with a deprecation notice for `getSurveyAnswers` as the Webropol Postman template suggests the new endpoint to be used instead

Based on #1, so includes the commit from there as well